### PR TITLE
Adding props for better content positioning

### DIFF
--- a/src/js/vue-context.js
+++ b/src/js/vue-context.js
@@ -42,6 +42,22 @@ export default {
             type: Number,
             default: 10
         },
+        useScrollHeight: {
+            type: Boolean,
+            default: false
+        },
+        useScrollWidth: {
+            type: Boolean,
+            default: false
+        },
+        heightOffset: {
+            type: Number,
+            default: 25
+        },
+        widthOffset: {
+            type: Number,
+            default: 25
+        },
         tag: {
             type: String,
             default: 'ul'
@@ -272,8 +288,19 @@ export default {
         },
 
         positionMenu(top, left, element) {
-            const largestHeight = window.innerHeight - element.offsetHeight - 25;
-            const largestWidth = window.innerWidth - element.offsetWidth - 25;
+            const largestHeight =
+                window.innerHeight -
+                (this.$props.useScrollHeight
+                    ? element.scrollHeight
+                    : element.offsetHeight) -
+                this.$props.heightOffset;
+
+            const largestWidth =
+                window.innerWidth -
+                (this.$props.useScrollWidth
+                    ? element.scrollWidth
+                    : element.offsetWidth) -
+                this.$props.widthOffset;
 
             if (top > largestHeight) {
                 top = largestHeight;


### PR DESCRIPTION
### Description of the Change

Adding the following props

- `useScrollHeight`
- `useScrollWidth`
- `heightOffset`
- `widthOffset`

### Benefits

The `useScrollHeight` and `useScrollWidth` props allow you to change the logic for calculating content sizes to correctly position the menu.

The `heightOffset` and `widthOffset` props allow you to set arbitrary indent values from the edge of the screen.

### Any additional information

In my case, the use of `scrollHeight` is required to correctly calculate the size of the context menu, provided that the initial size of the content is 0 pixels and will subsequently change using animation.