### PR TITLE
Proper setup of event listeners for sub-menus.

### DIFF
--- a/src/js/vue-context.js
+++ b/src/js/vue-context.js
@@ -99,12 +99,14 @@ export default {
         },
 
         addHoverEventListener(element) {
-            element.querySelectorAll('.v-context__sub').forEach(
-                subMenuNode => {
-                    eventOn(subMenuNode, 'mouseenter', this.openSubMenu);
-                    eventOn(subMenuNode, 'mouseleave', this.closeSubMenu);
-                }
-            );
+            this.$nextTick(() => {
+                element.querySelectorAll('.v-context__sub').forEach(
+                    subMenuNode => {
+                        eventOn(subMenuNode, 'mouseenter', this.openSubMenu);
+                        eventOn(subMenuNode, 'mouseleave', this.closeSubMenu);
+                    }
+                );
+            });
         },
 
         close() {


### PR DESCRIPTION
### Description of the Change

Updated 'addHoverEventListener' by wrapping the execution in the 'nextTick'. 

### Benefits

Proper setup of event listeners for sub-menus.

### Any additional information

The code tried to query elements with the 'v-context__sub' class within an element that was not rendered at that moment. The result of that is an empty set of elements, which ended up in the fact that sub-menus were not assigned an event listener. 

Because of that behavior, it was required to open a context menu twice in a row (for the initial menu to be rendered).